### PR TITLE
Load 'modelConverters' setting in apiSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ swagger {
         outputPath = "${project.rootDir}/generated/document.html"
         swaggerDirectory = "${project.rootDir}/generated/swagger-ui"
         swaggerApiReader = 'com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader'
+        modelConverters = [ 'io.swagger.validator.BeanValidator' ]
         // attachSwaggerArtifact = true - WILL BE ADDED IN THE FUTURE
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.benjaminsproule'
-version = '0.0.8'
+version = '0.0.9'
 
 buildscript {
     repositories {

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GenerateSwaggerDocsTask.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GenerateSwaggerDocsTask.groovy
@@ -63,6 +63,7 @@ class GenerateSwaggerDocsTask extends DefaultTask {
 
         documentSource.loadTypesToSkip();
         documentSource.loadModelModifier();
+        documentSource.loadModelConverters();
         documentSource.loadDocuments();
         if (swaggerPluginExtension.getOutputPath() != null) {
             File outputDirectory = new File(swaggerPluginExtension.getOutputPath()).getParentFile();


### PR DESCRIPTION
* swagger-maven-plugin supports custom implementations of io.swagger.ModelConverter to use when generating swagger files
* Update README.md with definition and example with 'modelConverters'
* Increment version to 0.0.9