### PR TITLE
Created a wrapper around slf4j so that logging adheres to the gradle …

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GenerateSwaggerDocsTask.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GenerateSwaggerDocsTask.groovy
@@ -2,12 +2,12 @@ package com.benjaminsproule.swagger.gradleplugin
 
 import com.benjaminsproule.swagger.gradleplugin.extension.ApiSourceExtension
 import com.benjaminsproule.swagger.gradleplugin.extension.SwaggerExtension
+import com.benjaminsproule.swagger.gradleplugin.logger.Slf4jWrapper
 import com.github.kongchen.swagger.docgen.AbstractDocumentSource
 import com.github.kongchen.swagger.docgen.GenerateException
 import com.github.kongchen.swagger.docgen.mavenplugin.MavenDocumentSource
 import com.github.kongchen.swagger.docgen.mavenplugin.SpringMavenDocumentSource
 import org.apache.maven.monitor.logging.DefaultLog
-import org.codehaus.plexus.logging.console.ConsoleLogger
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
@@ -58,9 +58,9 @@ class GenerateSwaggerDocsTask extends DefaultTask {
         AbstractDocumentSource documentSource
 
         if (swaggerPluginExtension.isSpringmvc()) {
-            documentSource = new SpringMavenDocumentSource(swaggerPluginExtension, new DefaultLog(new ConsoleLogger(0, 'name')))
+            documentSource = new SpringMavenDocumentSource(swaggerPluginExtension, new DefaultLog(new Slf4jWrapper()))
         } else {
-            documentSource = new MavenDocumentSource(swaggerPluginExtension, new DefaultLog(new ConsoleLogger(0, 'name')))
+            documentSource = new MavenDocumentSource(swaggerPluginExtension, new DefaultLog(new Slf4jWrapper()))
         }
 
         documentSource.loadTypesToSkip()

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/logger/Slf4jWrapper.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/logger/Slf4jWrapper.groovy
@@ -1,0 +1,101 @@
+package com.benjaminsproule.swagger.gradleplugin.logger
+
+import org.codehaus.plexus.logging.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * An slf4j wrapper for maven.
+ */
+class Slf4jWrapper implements Logger {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger('swagger-gradle-plugin')
+
+    @Override
+    void debug(String s) {
+        LOG.debug(s)
+    }
+
+    @Override
+    void debug(String s, Throwable throwable) {
+        LOG.debug(s, throwable)
+    }
+
+    @Override
+    boolean isDebugEnabled() {
+        return LOG.isDebugEnabled()
+    }
+
+    @Override
+    void info(String s) {
+        LOG.info(s)
+    }
+
+    @Override
+    void info(String s, Throwable throwable) {
+        LOG.info(s, throwable)
+    }
+
+    @Override
+    boolean isInfoEnabled() {
+        return LOG.isInfoEnabled()
+    }
+
+    @Override
+    void warn(String s) {
+        LOG.warn(s)
+    }
+
+    @Override
+    void warn(String s, Throwable throwable) {
+        LOG.warn(s, throwable)
+    }
+
+    @Override
+    boolean isWarnEnabled() {
+        return LOG.isWarnEnabled()
+    }
+
+    @Override
+    void error(String s) {
+        LOG.error(s)
+    }
+
+    @Override
+    void error(String s, Throwable throwable) {
+        LOG.error(s, throwable)
+    }
+
+    @Override
+    boolean isErrorEnabled() {
+        return LOG.isErrorEnabled()
+    }
+
+    @Override
+    void fatalError(String s) {
+        LOG.error(s)
+    }
+
+    @Override
+    void fatalError(String s, Throwable throwable) {
+        LOG.error(s, throwable)
+    }
+
+    @Override
+    boolean isFatalErrorEnabled() {
+        return LOG.isErrorEnabled()
+    }
+
+    @Override
+    Logger getChildLogger(String s) {
+        return this
+    }
+
+    @Override
+    int getThreshold() {
+        return 0
+    }
+
+    @Override
+    String getName() {
+        return LOG.getName()
+    }
+}


### PR DESCRIPTION
…log level

I was getting debug logs being written to Std out when doing gradle builds.

You probably want to test this with a few projects. It appears to be working for the projects i've tested it with.