### PR TITLE
Added the parameter types and parameters when creating a custom Abstr…

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/docgen/AbstractSwaggerLoader.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/docgen/AbstractSwaggerLoader.groovy
@@ -104,13 +104,14 @@ abstract class AbstractSwaggerLoader {
         return resolved
     }
 
-    protected static ClassSwaggerReader getCustomApiReader(Swagger swagger, String customReaderClassName) throws GenerateException {
+    protected ClassSwaggerReader getCustomApiReader(Swagger swagger, String customReaderClassName) throws GenerateException {
         try {
             LOG.info("Reading custom API reader: " + customReaderClassName)
             Class<?> clazz = Class.forName(customReaderClassName)
+
             if (AbstractReader.class.isAssignableFrom(clazz)) {
-                Constructor<?> constructor = clazz.getConstructor(Swagger.class)
-                return (ClassSwaggerReader) constructor.newInstance(swagger)
+                Constructor<?> constructor = clazz.getConstructor(ApiSourceExtension.class, Swagger.class, Set.class, List.class)
+                return (ClassSwaggerReader) constructor.newInstance(apiSource, swagger, null, null)
             } else {
                 return (ClassSwaggerReader) clazz.newInstance()
             }


### PR DESCRIPTION
It appears that customer swaggerApiReaders do not currently work, when trying to use one a method not found exception is thrown. 

This adds the parameter types to ensure the correct constructor is used along with passing the 2 available parameters of the 4.