### PR TITLE
Fix model substitution bugs

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
@@ -43,7 +43,6 @@ class ClassFinder {
         }
 
         Set<Class<?>> classes = new HashSet<Class<?>>()
-        ClassLoader classLoader = classLoader
 
         if (packages) {
             packages.each { location ->

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
@@ -56,20 +56,16 @@ class ClassFinder {
 
     private ClassLoader prepareClassLoader() {
         def urls = []
-        if (project.configurations.find { it.name == 'runtime' }) {
-            project.configurations.runtime.resolve().each {
-                urls.add(it.toURI().toURL())
-            }
+        project.configurations.runtime.resolve().each {
+            urls.add(it.toURI().toURL())
         }
 
-        if (project.find { it.name == 'sourceSets' }) {
-            if (project.sourceSets.main.output.getProperties()['classesDirs']) {
-                project.sourceSets.main.output.classesDirs.each {
-                    urls.add(it.toURI().toURL())
-                }
-            } else {
-                urls.add(project.sourceSets.main.output.classesDir.toURI().toURL())
+        if (project.sourceSets.main.output.getProperties()['classesDirs']) {
+            project.sourceSets.main.output.classesDirs.each {
+                urls.add(it.toURI().toURL())
             }
+        } else {
+            urls.add(project.sourceSets.main.output.classesDir.toURI().toURL())
         }
 
         return new URLClassLoader(urls as URL[], getClass().getClassLoader())

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
@@ -12,10 +12,12 @@ class ClassFinder {
     static instance
     Map<Class<? extends Annotation>, Set<Class<?>>> classCache
     Project project
+    private ClassLoader classLoader
 
     private ClassFinder(Project project) {
         this.project = project
         this.classCache = new HashMap<>()
+        this.classLoader = prepareClassLoader()
     }
 
     //FIXME hack until we have some DI working
@@ -25,6 +27,10 @@ class ClassFinder {
 
     static ClassFinder instance() {
         return instance
+    }
+
+    static Class<?> loadClass(String name) {
+        return instance.classLoader.loadClass(name)
     }
 
     Set<Class<?>> getValidClasses(Class<? extends Annotation> clazz) {
@@ -37,7 +43,7 @@ class ClassFinder {
         }
 
         Set<Class<?>> classes = new HashSet<Class<?>>()
-        ClassLoader classLoader = prepareClassLoader()
+        ClassLoader classLoader = classLoader
 
         if (packages) {
             packages.each { location ->

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
@@ -1,7 +1,6 @@
 package com.benjaminsproule.swagger.gradleplugin.classpath
 
 import org.gradle.api.Project
-import org.gradle.api.tasks.SourceSetOutput
 import org.reflections.Reflections
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -57,16 +56,20 @@ class ClassFinder {
 
     private ClassLoader prepareClassLoader() {
         def urls = []
-        project.configurations.runtime.resolve().each {
-            urls.add(it.toURI().toURL())
-        }
-
-        if (project.sourceSets.main.output.getProperties()['classesDirs']) {
-            project.sourceSets.main.output.classesDirs.each {
+        if (project.configurations.find { it.name == 'runtime' }) {
+            project.configurations.runtime.resolve().each {
                 urls.add(it.toURI().toURL())
             }
-        } else {
-            urls.add(project.sourceSets.main.output.classesDir.toURI().toURL())
+        }
+
+        if (project.find { it.name == 'sourceSets' }) {
+            if (project.sourceSets.main.output.getProperties()['classesDirs']) {
+                project.sourceSets.main.output.classesDirs.each {
+                    urls.add(it.toURI().toURL())
+                }
+            } else {
+                urls.add(project.sourceSets.main.output.classesDir.toURI().toURL())
+            }
         }
 
         return new URLClassLoader(urls as URL[], getClass().getClassLoader())

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/docgen/EnvironmentConfigurer.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/docgen/EnvironmentConfigurer.groovy
@@ -1,5 +1,6 @@
 package com.benjaminsproule.swagger.gradleplugin.docgen
 
+import com.benjaminsproule.swagger.gradleplugin.classpath.ResourceFinder
 import com.benjaminsproule.swagger.gradleplugin.except.GenerateException
 import com.benjaminsproule.swagger.gradleplugin.misc.EnhancedSwaggerModule
 import com.benjaminsproule.swagger.gradleplugin.model.ApiSourceExtension
@@ -84,7 +85,7 @@ class EnvironmentConfigurer {
         }
 
         if (apiSource.modelSubstitute) {
-            getClass().getResource(apiSource.modelSubstitute).eachLine { line ->
+            ResourceFinder.instance().getResourceAsStream(apiSource.modelSubstitute).eachLine { line ->
                 def classes = line.split(":")
                 if (classes.length != 2) {
                     throw new GenerateException('Bad format of override model file, it should be ${actualClassName}:${expectClassName}')

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/resolver/ModelModifier.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/resolver/ModelModifier.groovy
@@ -51,6 +51,7 @@ class ModelModifier extends ModelResolver {
     Property resolveProperty(Type type, ModelConverterContext context, Annotation[] annotations, Iterator<ModelConverter> chain) {
         // for method parameter types we get here Type but we need JavaType
         JavaType javaType = toJavaType(type)
+
         if (modelSubtitutes.containsKey(javaType)) {
             return super.resolveProperty(modelSubtitutes.get(javaType), context, annotations, chain)
         } else if (chain.hasNext()) {

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/resolver/ModelModifier.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/resolver/ModelModifier.groovy
@@ -1,5 +1,6 @@
 package com.benjaminsproule.swagger.gradleplugin.reader.resolver
 
+import com.benjaminsproule.swagger.gradleplugin.classpath.ClassFinder
 import com.benjaminsproule.swagger.gradleplugin.except.GenerateException
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -33,12 +34,12 @@ class ModelModifier extends ModelResolver {
         JavaType type = null
         JavaType toType = null
         try {
-            type = _mapper.constructType(Class.forName(fromClass))
+            type = _mapper.constructType(ClassFinder.loadClass(fromClass))
         } catch (ClassNotFoundException ignored) {
             LOG.warn("Problem with loading class: ${fromClass}. Mapping from: ${fromClass} to: ${toClass} will be ignored.")
         }
         try {
-            toType = _mapper.constructType(Class.forName(toClass))
+            toType = _mapper.constructType(ClassFinder.loadClass(toClass))
         } catch (ClassNotFoundException ignored) {
             LOG.warn("Problem with loading class: ${toClass}. Mapping from: ${fromClass} to: ${toClass} will be ignored.")
         }

--- a/src/main/resources/model-substitution
+++ b/src/main/resources/model-substitution
@@ -1,0 +1,1 @@
+java.lang.String : java.lang.Integer

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/JaxrsPluginTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/JaxrsPluginTest.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 import java.nio.file.Files
@@ -38,6 +39,7 @@ class JaxrsPluginTest {
                 apiSource {
                     locations = ['com.benjaminsproule']
                     schemes = ['http']
+                    modelSubstitute = ''
                     info {
                         title = project.name
                         version = '1'
@@ -62,10 +64,56 @@ class JaxrsPluginTest {
         project.tasks.generateSwaggerDocumentation.execute()
 
         def swaggerFile = new File("${expectedSwaggerDirectory}/swagger.json")
-        assertSwaggerJson(swaggerFile)
+        assertSwaggerJson(swaggerFile, 'string')
     }
 
-    private static void assertSwaggerJson(File swaggerJsonFile) {
+    @Test
+    @Ignore
+    /* this test is ignored because it adversely impacts the spring MVC plugin test, it is fine when run in isolation,
+    but as part of a suite, once a model modifier is registered in EnvironmentConfigurer by calling
+    ModelConverters.getInstance().addConverter(modelModifier), it is not possible to remove or clear it again unless
+    a new JVM is spun up meaning it is retained when running SpringMVCPluginTest.producesSwaggerDocumentation so
+    any strings are substituted for integers by the model substitution that is registered in this test */
+    void producesSwaggerDocumentationWithModelSubstitution() {
+        project.configurations.create('runtime')
+        project.plugins.apply JavaPlugin
+
+
+        def expectedSwaggerDirectory = "${project.buildDir}/swaggerui-" + UUID.randomUUID()
+        project.extensions.configure(SwaggerExtension, new ClosureBackedAction<SwaggerExtension>(
+            {
+                apiSource {
+                    locations = ['com.benjaminsproule']
+                    schemes = ['http']
+                    modelSubstitute = 'model-substitution'
+                    info {
+                        title = project.name
+                        version = '1'
+                        license {
+                            name = 'Apache 2.0'
+                        }
+                        contact {
+                            name = 'Joe Blogs'
+                        }
+                    }
+                    swaggerDirectory = expectedSwaggerDirectory
+                    host = 'localhost:8080'
+                    basePath = '/'
+                    securityDefinition {
+                        name = 'MyBasicAuth'
+                        type = 'basic'
+                    }
+                }
+            }
+        ))
+
+        project.tasks.generateSwaggerDocumentation.execute()
+
+        def swaggerFile = new File("${expectedSwaggerDirectory}/swagger.json")
+        assertSwaggerJson(swaggerFile, 'integer')
+    }
+
+    private static void assertSwaggerJson(File swaggerJsonFile, String type) {
         assert Files.exists(swaggerJsonFile.toPath())
 
         JsonSlurper jsonSlurper = new JsonSlurper()
@@ -95,7 +143,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/basic'.get.operationId == 'basic'
         assert paths.'/root/withannotation/basic'.get.produces == null
         assert paths.'/root/withannotation/basic'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/basic'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/basic'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/basic'.get.security.basic
         assert paths.'/root/withannotation/default'.get.tags == ['Test']
         assert paths.'/root/withannotation/default'.get.summary == 'A default operation'
@@ -111,7 +159,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/generics'.post.produces == null
         assert paths.'/root/withannotation/generics'.post.responses.'200'.description == 'successful operation'
         assert paths.'/root/withannotation/generics'.post.responses.'200'.schema.type == 'array'
-        assert paths.'/root/withannotation/generics'.post.responses.'200'.schema.items.type == 'string'
+        assert paths.'/root/withannotation/generics'.post.responses.'200'.schema.items.type == type
         assert paths.'/root/withannotation/generics'.post.security.basic
         assert paths.'/root/withannotation/datatype'.post.tags == ['Test']
         assert paths.'/root/withannotation/datatype'.post.summary == 'Consumes and Produces operation'
@@ -153,7 +201,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/deprecated'.get.operationId == 'deprecated'
         assert paths.'/root/withannotation/deprecated'.get.produces == null
         assert paths.'/root/withannotation/deprecated'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/deprecated'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/deprecated'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/deprecated'.get.security.basic
         assert paths.'/root/withannotation/auth'.get.tags == ['Test']
         assert paths.'/root/withannotation/auth'.get.summary == 'An auth operation'
@@ -161,7 +209,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/auth'.get.operationId == 'withAuth'
         assert paths.'/root/withannotation/auth'.get.produces == null
         assert paths.'/root/withannotation/auth'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/auth'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/auth'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/auth'.get.security.basic
         assert paths.'/root/withannotation/model'.get.tags == ['Test']
         assert paths.'/root/withannotation/model'.get.summary == 'A model operation'
@@ -169,7 +217,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/model'.get.operationId == 'model'
         assert paths.'/root/withannotation/model'.get.produces == null
         assert paths.'/root/withannotation/model'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/model'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/model'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/model'.get.security.basic
         assert paths.'/root/withannotation/overriden'.get.tags == ['Test']
         assert paths.'/root/withannotation/overriden'.get.summary == 'An overriden operation description'
@@ -177,7 +225,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/overriden'.get.operationId == 'overriden'
         assert paths.'/root/withannotation/overriden'.get.produces == null
         assert paths.'/root/withannotation/overriden'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/overriden'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/overriden'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/overriden'.get.security.basic
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.tags == ['Test']
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.summary == 'An overriden operation'
@@ -185,7 +233,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.operationId == 'overridenWithoutDescription'
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.produces == null
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.security.basic
         assert paths.'/root/withannotation/hidden' == null
         assert paths.'/root/withoutannotation/basic'.get.tags == ['Test']
@@ -194,7 +242,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/basic'.get.operationId == 'basic'
         assert paths.'/root/withoutannotation/basic'.get.produces == null
         assert paths.'/root/withoutannotation/basic'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/basic'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/basic'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/basic'.get.security.basic
         assert paths.'/root/withoutannotation/default'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/default'.get.summary == 'A default operation'
@@ -210,7 +258,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/generics'.post.produces == null
         assert paths.'/root/withoutannotation/generics'.post.responses.'200'.description == 'successful operation'
         assert paths.'/root/withoutannotation/generics'.post.responses.'200'.schema.type == 'array'
-        assert paths.'/root/withoutannotation/generics'.post.responses.'200'.schema.items.type == 'string'
+        assert paths.'/root/withoutannotation/generics'.post.responses.'200'.schema.items.type == type
         assert paths.'/root/withoutannotation/generics'.post.security.basic
         assert paths.'/root/withoutannotation/datatype'.post.tags == ['Test']
         assert paths.'/root/withoutannotation/datatype'.post.summary == 'Consumes and Produces operation'
@@ -252,7 +300,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/deprecated'.get.operationId == 'deprecated'
         assert paths.'/root/withoutannotation/deprecated'.get.produces == null
         assert paths.'/root/withoutannotation/deprecated'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/deprecated'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/deprecated'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/deprecated'.get.security.basic
         assert paths.'/root/withoutannotation/auth'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/auth'.get.summary == 'An auth operation'
@@ -260,7 +308,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/auth'.get.operationId == 'withAuth'
         assert paths.'/root/withoutannotation/auth'.get.produces == null
         assert paths.'/root/withoutannotation/auth'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/auth'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/auth'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/auth'.get.security.basic
         assert paths.'/root/withoutannotation/model'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/model'.get.summary == 'A model operation'
@@ -268,7 +316,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/model'.get.operationId == 'model'
         assert paths.'/root/withoutannotation/model'.get.produces == null
         assert paths.'/root/withoutannotation/model'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/model'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/model'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/model'.get.security.basic
         assert paths.'/root/withoutannotation/overriden'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/overriden'.get.summary == 'An overriden operation description'
@@ -276,7 +324,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/overriden'.get.operationId == 'overriden'
         assert paths.'/root/withoutannotation/overriden'.get.produces == null
         assert paths.'/root/withoutannotation/overriden'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/overriden'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/overriden'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/overriden'.get.security.basic
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.summary == 'An overriden operation'
@@ -284,7 +332,7 @@ class JaxrsPluginTest {
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.operationId == 'overridenWithoutDescription'
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.produces == null
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.security.basic
         assert paths.'/root/withoutannotation/hidden' == null
     }

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/JaxrsPluginTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/JaxrsPluginTest.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 import java.nio.file.Files
@@ -20,6 +19,8 @@ class JaxrsPluginTest {
     void setUp() {
         project = ProjectBuilder.builder().build()
         project.pluginManager.apply 'com.benjaminsproule.swagger'
+
+        ModelModifierRemover.removeAllModelModifiers()
     }
 
     @After
@@ -68,12 +69,6 @@ class JaxrsPluginTest {
     }
 
     @Test
-    @Ignore
-    /* this test is ignored because it adversely impacts the spring MVC plugin test, it is fine when run in isolation,
-    but as part of a suite, once a model modifier is registered in EnvironmentConfigurer by calling
-    ModelConverters.getInstance().addConverter(modelModifier), it is not possible to remove or clear it again unless
-    a new JVM is spun up meaning it is retained when running SpringMVCPluginTest.producesSwaggerDocumentation so
-    any strings are substituted for integers by the model substitution that is registered in this test */
     void producesSwaggerDocumentationWithModelSubstitution() {
         project.configurations.create('runtime')
         project.plugins.apply JavaPlugin

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/ModelModifierRemover.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/ModelModifierRemover.groovy
@@ -1,0 +1,17 @@
+package com.benjaminsproule.swagger.gradleplugin
+
+import com.benjaminsproule.swagger.gradleplugin.reader.resolver.ModelModifier
+import io.swagger.converter.ModelConverters
+
+class ModelModifierRemover {
+
+    static removeAllModelModifiers() {
+        def modelConverters = ModelConverters.getInstance()
+        modelConverters.converters.each {
+            if (it.getClass() == ModelModifier.class) {
+                modelConverters.removeConverter(it)
+            }
+        }
+    }
+
+}

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcPluginTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcPluginTest.groovy
@@ -39,6 +39,7 @@ class SpringMvcPluginTest {
                     locations = ['com.benjaminsproule']
                     springmvc = true
                     schemes = ['http']
+                    modelSubstitute = ''
                     info {
                         title = project.name
                         version = '1'
@@ -63,10 +64,56 @@ class SpringMvcPluginTest {
         project.tasks.generateSwaggerDocumentation.execute()
 
         def swaggerFile = new File("${expectedSwaggerDirectory}/swagger.json")
-        assertSwaggerJson(swaggerFile)
+        assertSwaggerJson(swaggerFile, 'string')
     }
 
-    private static void assertSwaggerJson(File swaggerJsonFile) {
+    @Test
+    /* IMPORTATNT NOTE as part of a suite, once a model modifier is registered in EnvironmentConfigurer by calling
+    ModelConverters.getInstance().addConverter(modelModifier), it is not possible to remove or clear it again unless
+    a new JVM is spun up meaning the model modifier is retained for all subsequent tests so
+    any strings will be substituted for integers by the model substitution that is registered in this test when any
+    other document generation tasks are called */
+    void producesSwaggerDocumentationWithModelSubstitution() {
+        project.configurations.create('runtime')
+        project.plugins.apply JavaPlugin
+
+
+        def expectedSwaggerDirectory = "${project.buildDir}/swaggerui-" + UUID.randomUUID()
+        project.extensions.configure(SwaggerExtension, new ClosureBackedAction<SwaggerExtension>(
+            {
+                apiSource {
+                    locations = ['com.benjaminsproule']
+                    springmvc = true
+                    schemes = ['http']
+                    modelSubstitute = 'model-substitution'
+                    info {
+                        title = project.name
+                        version = '1'
+                        license {
+                            name = 'Apache 2.0'
+                        }
+                        contact {
+                            name = 'Joe Blogs'
+                        }
+                    }
+                    swaggerDirectory = expectedSwaggerDirectory
+                    host = 'localhost:8080'
+                    basePath = '/'
+                    securityDefinition {
+                        name = 'MyBasicAuth'
+                        type = 'basic'
+                    }
+                }
+            }
+        ))
+
+        project.tasks.generateSwaggerDocumentation.execute()
+
+        def swaggerFile = new File("${expectedSwaggerDirectory}/swagger.json")
+        assertSwaggerJson(swaggerFile, 'integer')
+    }
+
+    private static void assertSwaggerJson(File swaggerJsonFile, String type) {
         assert Files.exists(swaggerJsonFile.toPath())
 
         JsonSlurper jsonSlurper = new JsonSlurper()
@@ -96,7 +143,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/basic'.get.operationId == 'basic'
         assert paths.'/root/withannotation/basic'.get.produces == null
         assert paths.'/root/withannotation/basic'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/basic'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/basic'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/basic'.get.security.basic
         assert paths.'/root/withannotation/default'.get.tags == ['Test']
         assert paths.'/root/withannotation/default'.get.summary == 'A default operation'
@@ -112,7 +159,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/generics'.post.produces == null
         assert paths.'/root/withannotation/generics'.post.responses.'200'.description == 'successful operation'
         assert paths.'/root/withannotation/generics'.post.responses.'200'.schema.type == 'array'
-        assert paths.'/root/withannotation/generics'.post.responses.'200'.schema.items.type == 'string'
+        assert paths.'/root/withannotation/generics'.post.responses.'200'.schema.items.type == type
         assert paths.'/root/withannotation/generics'.post.security.basic
         assert paths.'/root/withannotation/datatype'.post.tags == ['Test']
         assert paths.'/root/withannotation/datatype'.post.summary == 'Consumes and Produces operation'
@@ -154,7 +201,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/deprecated'.get.operationId == 'deprecated'
         assert paths.'/root/withannotation/deprecated'.get.produces == null
         assert paths.'/root/withannotation/deprecated'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/deprecated'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/deprecated'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/deprecated'.get.security.basic
         assert paths.'/root/withannotation/auth'.get.tags == ['Test']
         assert paths.'/root/withannotation/auth'.get.summary == 'An auth operation'
@@ -162,7 +209,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/auth'.get.operationId == 'withAuth'
         assert paths.'/root/withannotation/auth'.get.produces == null
         assert paths.'/root/withannotation/auth'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/auth'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/auth'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/auth'.get.security.basic
         assert paths.'/root/withannotation/model'.get.tags == ['Test']
         assert paths.'/root/withannotation/model'.get.summary == 'A model operation'
@@ -170,7 +217,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/model'.get.operationId == 'model'
         assert paths.'/root/withannotation/model'.get.produces == null
         assert paths.'/root/withannotation/model'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/model'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/model'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/model'.get.security.basic
         assert paths.'/root/withannotation/overriden'.get.tags == ['Test']
         assert paths.'/root/withannotation/overriden'.get.summary == 'An overriden operation description'
@@ -178,7 +225,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/overriden'.get.operationId == 'overriden'
         assert paths.'/root/withannotation/overriden'.get.produces == null
         assert paths.'/root/withannotation/overriden'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/overriden'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/overriden'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/overriden'.get.security.basic
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.tags == ['Test']
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.summary == 'An overriden operation'
@@ -186,7 +233,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.operationId == 'overridenWithoutDescription'
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.produces == null
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == type
         assert paths.'/root/withannotation/overridenWithoutDescription'.get.security.basic
         assert paths.'/root/withannotation/hidden' == null
         assert paths.'/root/withoutannotation/basic'.get.tags == ['Test']
@@ -195,7 +242,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/basic'.get.operationId == 'basic'
         assert paths.'/root/withoutannotation/basic'.get.produces == null
         assert paths.'/root/withoutannotation/basic'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/basic'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/basic'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/basic'.get.security.basic
         assert paths.'/root/withoutannotation/default'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/default'.get.summary == 'A default operation'
@@ -211,7 +258,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/generics'.post.produces == null
         assert paths.'/root/withoutannotation/generics'.post.responses.'200'.description == 'successful operation'
         assert paths.'/root/withoutannotation/generics'.post.responses.'200'.schema.type == 'array'
-        assert paths.'/root/withoutannotation/generics'.post.responses.'200'.schema.items.type == 'string'
+        assert paths.'/root/withoutannotation/generics'.post.responses.'200'.schema.items.type == type
         assert paths.'/root/withoutannotation/generics'.post.security.basic
         assert paths.'/root/withoutannotation/datatype'.post.tags == ['Test']
         assert paths.'/root/withoutannotation/datatype'.post.summary == 'Consumes and Produces operation'
@@ -253,7 +300,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/deprecated'.get.operationId == 'deprecated'
         assert paths.'/root/withoutannotation/deprecated'.get.produces == null
         assert paths.'/root/withoutannotation/deprecated'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/deprecated'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/deprecated'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/deprecated'.get.security.basic
         assert paths.'/root/withoutannotation/auth'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/auth'.get.summary == 'An auth operation'
@@ -261,7 +308,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/auth'.get.operationId == 'withAuth'
         assert paths.'/root/withoutannotation/auth'.get.produces == null
         assert paths.'/root/withoutannotation/auth'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/auth'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/auth'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/auth'.get.security.basic
         assert paths.'/root/withoutannotation/model'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/model'.get.summary == 'A model operation'
@@ -269,7 +316,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/model'.get.operationId == 'model'
         assert paths.'/root/withoutannotation/model'.get.produces == null
         assert paths.'/root/withoutannotation/model'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/model'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/model'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/model'.get.security.basic
         assert paths.'/root/withoutannotation/overriden'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/overriden'.get.summary == 'An overriden operation description'
@@ -277,7 +324,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/overriden'.get.operationId == 'overriden'
         assert paths.'/root/withoutannotation/overriden'.get.produces == null
         assert paths.'/root/withoutannotation/overriden'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/overriden'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/overriden'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/overriden'.get.security.basic
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.tags == ['Test']
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.summary == 'An overriden operation'
@@ -285,7 +332,7 @@ class SpringMvcPluginTest {
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.operationId == 'overridenWithoutDescription'
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.produces == null
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.responses.'200'.description == 'successful operation'
-        assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == 'string'
+        assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.responses.'200'.schema.type == type
         assert paths.'/root/withoutannotation/overridenWithoutDescription'.get.security.basic
         assert paths.'/root/withoutannotation/hidden' == null
     }

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcPluginTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcPluginTest.groovy
@@ -19,6 +19,8 @@ class SpringMvcPluginTest {
     void setUp() {
         project = ProjectBuilder.builder().build()
         project.pluginManager.apply 'com.benjaminsproule.swagger'
+
+        ModelModifierRemover.removeAllModelModifiers()
     }
 
     @After

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcPluginTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcPluginTest.groovy
@@ -70,11 +70,6 @@ class SpringMvcPluginTest {
     }
 
     @Test
-    /* IMPORTATNT NOTE as part of a suite, once a model modifier is registered in EnvironmentConfigurer by calling
-    ModelConverters.getInstance().addConverter(modelModifier), it is not possible to remove or clear it again unless
-    a new JVM is spun up meaning the model modifier is retained for all subsequent tests so
-    any strings will be substituted for integers by the model substitution that is registered in this test when any
-    other document generation tasks are called */
     void producesSwaggerDocumentationWithModelSubstitution() {
         project.configurations.create('runtime')
         project.plugins.apply JavaPlugin

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy
@@ -73,7 +73,7 @@ class ApiSourceExtensionTest extends Specification {
         apiSourceExtension.basePath = '/'
         apiSourceExtension.locations = ['com.benjaminsproule']
         apiSourceExtension.schemes = ['http']
-        apiSourceExtension.descriptionFile = new File("src/test/resources/api-description/description.txt")
+        apiSourceExtension.descriptionFile = loadFileFromClasspath("/api-description/description.txt")
         apiSourceExtension.info = Mock(InfoExtension)
         apiSourceExtension.info.asSwaggerType() >> new Info()
         apiSourceExtension.securityDefinition = Mock(SecurityDefinitionExtension)
@@ -92,4 +92,10 @@ class ApiSourceExtensionTest extends Specification {
 with multiple lines'''
         assert result.securityDefinitions
     }
+
+    private static File loadFileFromClasspath(String path) {
+        URL url = ApiSourceExtensionTest.class.getResource(path)
+        return new File(url.toURI())
+    }
+
 }

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy
@@ -1,10 +1,10 @@
 package com.benjaminsproule.swagger.gradleplugin.model
 
+import com.benjaminsproule.swagger.gradleplugin.classpath.ClassFinder
 import io.swagger.models.Info
 import io.swagger.models.Scheme
 import io.swagger.models.auth.BasicAuthDefinition
 import org.gradle.testfixtures.ProjectBuilder
-import spock.lang.Ignore
 import spock.lang.Specification
 
 class ApiSourceExtensionTest extends Specification {
@@ -12,6 +12,7 @@ class ApiSourceExtensionTest extends Specification {
 
     def setup() {
         def project = ProjectBuilder.builder().build()
+        ClassFinder.createInstance(project)
         apiSourceExtension = new ApiSourceExtension(project)
     }
 
@@ -28,7 +29,6 @@ class ApiSourceExtensionTest extends Specification {
         assert !result
     }
 
-    @Ignore("Need to sort out the classfinder before this is going to work")
     def 'Api Source with missing info should provide missing info error'() {
         setup:
         apiSourceExtension.locations = ['com.github.junk'] //make sure we don't discover any annotations
@@ -38,7 +38,8 @@ class ApiSourceExtensionTest extends Specification {
 
         then:
         assert result
-        assert result.contains('Info is required by the swagger spec.')
+        assert result.contains('info.title is required by the swagger spec')
+        assert result.contains('info.version is required by the swagger spec')
     }
 
     def 'Api Source with no locations should provide missing locations error'() {

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy
@@ -4,15 +4,17 @@ import com.benjaminsproule.swagger.gradleplugin.classpath.ClassFinder
 import io.swagger.models.Info
 import io.swagger.models.Scheme
 import io.swagger.models.auth.BasicAuthDefinition
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class ApiSourceExtensionTest extends Specification {
+    Project project
     ApiSourceExtension apiSourceExtension
 
     def setup() {
-        def project = ProjectBuilder.builder().build()
-        ClassFinder.createInstance(project)
+        project = ProjectBuilder.builder().build()
         apiSourceExtension = new ApiSourceExtension(project)
     }
 
@@ -31,6 +33,9 @@ class ApiSourceExtensionTest extends Specification {
 
     def 'Api Source with missing info should provide missing info error'() {
         setup:
+        project.configurations.create('runtime')
+        project.plugins.apply JavaPlugin
+        ClassFinder.createInstance(project)
         apiSourceExtension.locations = ['com.github.junk'] //make sure we don't discover any annotations
 
         when:


### PR DESCRIPTION
This PR fixes some existing tests:

- src/test/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtensionTest.groovy as this was failing for me locally on my mac
- 'Api Source with missing info should provide missing info error' in ApiSourceExtensionTest.groovy as this had previously been ignored
- Adds tests for model substitution (one for JAXRS is currently ignored, as it also uncovered a limitation in the core swagger library which made resetting the config in between tests not possible without running each test in a new JVM, which would be very slow!)
- Fixes a bug when trying to do a model substitution using a class that comes from a dependency rather than directly in project source, this wasn't possible to write a test for, so I created this repo to demo it instead: https://github.com/michaelruocco/swagger-gradle-plugin-error-demo.