### PR TITLE
Add default tag when no tags on Api or Operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ swagger {
 | `jsonExampleValues` | If `true`, all example values in `@ApiModelProperty` will be handled as json raw values. This is useful for creating valid examples in the generated json for all property types, including non-string ones. |
 | `modelConverters` | List of custom implementations of `io.swagger.converter.ModelConverter` that should be used when generating the swagger files. More details [below](#modelConverters)|
 | `excludePattern` | Regex of files that will be excluded from the swagger documentation. The default is `.*\\.pom` so it ignores all pom files. |
+| `tagStrategy` | Default no. `class` use class name if no tags are set to group operations specific to controller. (currently only springmvc)  |
 
 # <a id="templatefile">Template File</a>
 

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtension.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtension.groovy
@@ -30,6 +30,7 @@ class ApiSourceExtension {
     boolean useJAXBAnnotationProcessorAsPrimary = true
     boolean jsonExampleValues = false
     boolean attachSwaggerArtifact
+    String tagStrategy   // null | "class"
     File descriptionFile
     List<String> swaggerExtensions
     List<String> typesToSkipList = []

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/SpringMvcApiReader.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/SpringMvcApiReader.groovy
@@ -116,7 +116,7 @@ class SpringMvcApiReader extends AbstractReader {
             tags = updateTagsForApi(null, api)
             resourceSecurities = getSecurityRequirements(api)
             apiDescription = api.description()
-        } else {
+        } else if(StringUtils.equals("class", apiSource.tagStrategy)) {
           // Apply a default tag when no Api present
           io.swagger.models.Tag controllerTag  = new io.swagger.models.Tag().name(controller.getSimpleName())
           tags.put(controllerTag.getName(), controllerTag)

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/SpringMvcApiReader.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/SpringMvcApiReader.groovy
@@ -116,6 +116,11 @@ class SpringMvcApiReader extends AbstractReader {
             tags = updateTagsForApi(null, api)
             resourceSecurities = getSecurityRequirements(api)
             apiDescription = api.description()
+        } else {
+          // Apply a default tag when no Api present
+          io.swagger.models.Tag controllerTag  = new io.swagger.models.Tag().name(controller.getSimpleName())
+          tags.put(controllerTag.getName(), controllerTag)
+          swagger.tag(controllerTag)
         }
 
         if (resource.controllerClass.isAnnotationPresent(RequestMapping)) {

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcSampleITest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcSampleITest.groovy
@@ -66,5 +66,82 @@ class SpringMvcSampleITest extends AbstractPluginITest {
         assert paths."/api/sample".post
         assert paths."/api/sample".post.operationId == "postSample"
     }
- 
+    
+    def 'Produces tag for controller when no Api'() {
+      given:
+      def expectedSwaggerDirectory = "${testProjectOutputDir}/swaggerui-" + UUID.randomUUID()
+      buildFile << """
+            plugins {
+                id 'java'
+                id 'groovy'
+                id 'com.benjaminsproule.swagger'
+            }
+            swagger {
+                apiSource {
+                    springmvc = true
+                    host = 'localhost:8080'
+                    basePath = '/'
+                    info {
+                        title = 'test'
+                        version = '1'
+                    }
+                    swaggerDirectory = '${expectedSwaggerDirectory}'
+                    ${testSpecificConfig}
+                }
+            }
+        """
+       when:
+      def result = runPluginTask()
+       then:
+      result.task(":${GenerateSwaggerDocsTask.TASK_NAME}").outcome == SUCCESS
+       assertSwaggerJsonTags("${expectedSwaggerDirectory}/swagger.json")
+       where:
+      testSpecificConfig << [
+          """
+              locations = ['com.benjaminsproule.swagger.gradleplugin.test.springmvc']
+          """
+      ]
+  }
+  
+  private static void assertSwaggerJsonTags(String swaggerJsonFile) {
+    def producedSwaggerDocument = new JsonSlurper().parse(new File(swaggerJsonFile), 'UTF-8')
+    
+    assert producedSwaggerDocument.swagger == '2.0'
+    assert producedSwaggerDocument.basePath == '/'
+    
+    def info = producedSwaggerDocument.info
+    assert info
+    assert info.version == '1'
+    assert info.title == 'test'
+    
+    def paths = producedSwaggerDocument.get('paths')
+    assert paths
+    assert paths.size() == 4
+    assert paths."/api/sample".get
+    assert paths."/api/sample".get.operationId == "getSample"
+    assert paths."/api/sample".get.tags == ['SampleController']
+    assert paths."/api/sample".post
+    assert paths."/api/sample".post.operationId == "postSample"
+    assert paths."/api/sample".post.tags == ['SampleController']
+    
+    assert paths."/api/other".get
+    assert paths."/api/other".get.operationId == "getOther"
+    assert paths."/api/other".get.tags == ['OtherController']
+    assert paths."/api/other".post
+    assert paths."/api/other".post.operationId == "createOther"
+    assert paths."/api/other".post.tags == ['OtherController']
+    
+    assert paths."/api/pets".get
+    assert paths."/api/pets".get.operationId == "getPets"
+    assert paths."/api/pets".get.tags == ['pets']
+    assert paths."/api/pets/eagles".get
+    assert paths."/api/pets/eagles".get.operationId == "getEagles"
+    assert paths."/api/pets/eagles".get.tags == ['eagles']
+    
+    def tags = producedSwaggerDocument.get('tags')
+    assert tags
+    assert tags.size() == 4
+    assert tags.sort() == [[name:'eagles'], [name:'OtherController'], [name:'pets'], [name:'SampleController']]
+  }
+
 }

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcSampleITest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcSampleITest.groovy
@@ -69,7 +69,7 @@ class SpringMvcSampleITest extends AbstractPluginITest {
     
     def 'Produces tag for controller when no Api'() {
       given:
-      def expectedSwaggerDirectory = "${testProjectOutputDir}/swaggerui-" + UUID.randomUUID()
+      def expectedSwaggerDirectory = "${testProjectOutputDirAsString}/swaggerui-" + UUID.randomUUID()
       buildFile << """
             plugins {
                 id 'java'
@@ -85,6 +85,7 @@ class SpringMvcSampleITest extends AbstractPluginITest {
                         title = 'test'
                         version = '1'
                     }
+                    tagStrategy = "class"
                     swaggerDirectory = '${expectedSwaggerDirectory}'
                     ${testSpecificConfig}
                 }

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcSampleITest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/SpringMvcSampleITest.groovy
@@ -117,6 +117,7 @@ class SpringMvcSampleITest extends AbstractPluginITest {
     def paths = producedSwaggerDocument.get('paths')
     assert paths
     assert paths.size() == 4
+
     assert paths."/api/sample".get
     assert paths."/api/sample".get.operationId == "getSample"
     assert paths."/api/sample".get.tags == ['SampleController']

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/springmvc/OtherController.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/springmvc/OtherController.groovy
@@ -1,0 +1,21 @@
+package com.benjaminsproule.swagger.gradleplugin.test.springmvc
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/other")
+public class OtherController {
+
+    @GetMapping
+    public String getOther() {
+      return "";
+    }
+
+    @PostMapping
+    public String createOther() {
+      return "";
+    }
+}

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/springmvc/PetController.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/springmvc/PetController.groovy
@@ -1,0 +1,26 @@
+package com.benjaminsproule.swagger.gradleplugin.test.springmvc
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+
+@RestController
+@RequestMapping("/api/pets")
+@Api(tags=["pets"])  // tags take precedence to default creation
+public class PetController {
+
+    @GetMapping
+    public String getPets() {
+      return "";
+    }
+
+    @GetMapping(path="/eagles")
+    @ApiOperation(value="Get all eagles", tags=["eagles"])  // tags take precendence over default and @Api
+    public String getEagles() {
+      return "";
+    }
+}


### PR DESCRIPTION
Fixes #87 

A tag with the SimpleClassName of the controller will be created when no `@Api` is set.  
This tag will also be assigned to all methods/operations which have no tags.
So this works like `@Api.tags` are assigned to methods/operations.
