### PR TITLE
Model subst: match fromClass by name, not class object

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtension.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtension.groovy
@@ -1,10 +1,6 @@
 package com.benjaminsproule.swagger.gradleplugin.model
 
 import groovy.transform.ToString
-
-import java.util.List
-import java.util.Map
-
 import org.gradle.api.Project
 
 @ToString(includeNames = true)


### PR DESCRIPTION
This fixes issues with classes being loaded in different classloaders.

I'm not sure how widespread this problem is. It's possible it only happens in particularly complicated builds; I haven't tested to narrow down the specific cause. It fixed model substitution in our build, which is good enough for me.