### PR TITLE
(backwards incompatible) Model subst map in Gradle extension

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/misc/EnvironmentConfigurer.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/misc/EnvironmentConfigurer.groovy
@@ -88,14 +88,8 @@ class EnvironmentConfigurer {
             modelModifier.setApiModelPropertyAccessExclusions(apiSourceExtension.apiModelPropertyAccessExclusionsList)
         }
 
-        if (apiSourceExtension.modelSubstitute) {
-            classFinder.getClassLoader().getResourceAsStream(apiSourceExtension.modelSubstitute).eachLine { line ->
-                def classes = line.split(":")
-                if (classes.length != 2) {
-                    throw new GenerateException('Bad format of override model file, it should be ${actualClassName}:${expectClassName}')
-                }
-                modelModifier.addModelSubstitute(classes[0].trim(), classes[1].trim())
-            }
+        apiSourceExtension.modelSubstitutions.each { actual, expect ->
+            modelModifier.addModelSubstitute(actual, expect)
         }
 
         modelModifiers += modelModifier

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtension.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/model/ApiSourceExtension.groovy
@@ -22,7 +22,7 @@ class ApiSourceExtension {
     String outputPath
     String swaggerDirectory
     String swaggerFileName = "swagger"
-    String modelSubstitute
+    Map<String, String> modelSubstitutions = [:]
     String swaggerInternalFilter
     String swaggerApiReader
     boolean springmvc


### PR DESCRIPTION
It's much cleaner to put these substitutions in the buildscript than to put them in a file to be loaded from buildSrc.

Replaces the modelSubstitute option (resource file name) with a modelSubstitutions option (map of fromClass name to toClass name).

This PR probably shouldn't be accepted until someone (me, if I get time) adds some documentation updates. It also should probably be scheduled for the next major version bump, seeing as how it's backwards-incompatible.