### PR TITLE
Primitive type support for implicit parameters

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/AbstractReader.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/AbstractReader.groovy
@@ -15,6 +15,8 @@ import io.swagger.models.properties.Property
 import io.swagger.models.properties.RefProperty
 import io.swagger.util.ParameterProcessor
 import io.swagger.util.PathUtils
+import io.swagger.util.PrimitiveType
+import io.swagger.util.ReflectionUtils
 import org.apache.commons.lang3.reflect.TypeUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -422,7 +424,7 @@ abstract class AbstractReader implements ClassSwaggerReader {
             return
         }
         for (ApiImplicitParam param : implicitParams.value()) {
-            Class<?> cls = Class.forName(param.dataType())
+            Class<?> cls = ReflectionUtils.typeFromString(param.dataType());
 
             Parameter p = readImplicitParam(param, cls)
             if (p != null) {

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/AbstractReader.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/AbstractReader.groovy
@@ -15,7 +15,6 @@ import io.swagger.models.properties.Property
 import io.swagger.models.properties.RefProperty
 import io.swagger.util.ParameterProcessor
 import io.swagger.util.PathUtils
-import io.swagger.util.PrimitiveType
 import io.swagger.util.ReflectionUtils
 import org.apache.commons.lang3.reflect.TypeUtils
 import org.slf4j.Logger

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/AbstractReader.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/AbstractReader.groovy
@@ -425,6 +425,10 @@ abstract class AbstractReader implements ClassSwaggerReader {
         for (ApiImplicitParam param : implicitParams.value()) {
             Class<?> cls = ReflectionUtils.typeFromString(param.dataType());
 
+            if (param.dataType()?.trim() && !cls) {
+                throw new ClassNotFoundException(param.dataType());
+            }
+
             Parameter p = readImplicitParam(param, cls)
             if (p != null) {
                 operation.addParameter(p)

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/MissingImplicitParamsITest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/MissingImplicitParamsITest.groovy
@@ -30,7 +30,7 @@ class MissingImplicitParamsITest extends AbstractPluginITest {
 
         then:
         result.task(":${GenerateSwaggerDocsTask.TASK_NAME}").outcome == FAILED
-        result.output.contains("Unrecognized Type: [null]")
+        result.output.contains("Caused by: java.lang.ClassNotFoundException: com.benjaminsproule.swagger.gradleplugin.test.model.MissingRequestModel")
 
         where:
         testSpecificConfig << [

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/MissingImplicitParamsITest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/MissingImplicitParamsITest.groovy
@@ -30,7 +30,7 @@ class MissingImplicitParamsITest extends AbstractPluginITest {
 
         then:
         result.task(":${GenerateSwaggerDocsTask.TASK_NAME}").outcome == FAILED
-        result.output.contains("Caused by: java.lang.ClassNotFoundException: com.benjaminsproule.swagger.gradleplugin.test.model.MissingRequestModel")
+        result.output.contains("Unrecognized Type: [null]")
 
         where:
         testSpecificConfig << [

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/groovy/jaxrs/TestResourceWithClassAnnotation.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/groovy/jaxrs/TestResourceWithClassAnnotation.groovy
@@ -147,9 +147,10 @@ class TestResourceWithClassAnnotation {
     }
 
     @ApiOperation(value = 'An implicit params operation')
-    @ApiImplicitParams(
-        @ApiImplicitParam(name = 'body', required = true, dataType = 'com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel', paramType = 'body')
-    )
+    @ApiImplicitParams([
+        @ApiImplicitParam(name = 'body', required = true, dataType = 'com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel', paramType = 'body'),
+        @ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
+    ])
     @Path('/implicitparams')
     @POST
     String implicitParams(String requestModel) {

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/groovy/springmvc/TestResourceWithClassAnnotation.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/test/groovy/springmvc/TestResourceWithClassAnnotation.groovy
@@ -130,9 +130,10 @@ class TestResourceWithClassAnnotation {
     }
 
     @ApiOperation(value = 'An implicit params operation')
-    @ApiImplicitParams(
-        @ApiImplicitParam(name = 'body', required = true, dataType = 'com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel', paramType = 'body')
-    )
+    @ApiImplicitParams([
+        @ApiImplicitParam(name = 'body', required = true, dataType = 'com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel', paramType = 'body'),
+        @ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
+    ])
     @RequestMapping(path = '/implicitparams', method = RequestMethod.POST)
     String implicitParams(String requestModel) {
         return ''

--- a/src/test/java/com/benjaminsproule/swagger/gradleplugin/test/java/jaxrs/TestResourceWithClassAnnotation.java
+++ b/src/test/java/com/benjaminsproule/swagger/gradleplugin/test/java/jaxrs/TestResourceWithClassAnnotation.java
@@ -147,9 +147,10 @@ public class TestResourceWithClassAnnotation {
     }
 
     @ApiOperation(value = "An implicit params operation")
-    @ApiImplicitParams(
-        @ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body")
-    )
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body"),
+        @ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
+    })
     @Path("/implicitparams")
     @POST
     public String implicitParams(String requestModel) {

--- a/src/test/java/com/benjaminsproule/swagger/gradleplugin/test/java/springmvc/TestResourceWithClassAnnotation.java
+++ b/src/test/java/com/benjaminsproule/swagger/gradleplugin/test/java/springmvc/TestResourceWithClassAnnotation.java
@@ -132,9 +132,10 @@ public class TestResourceWithClassAnnotation {
     }
 
     @ApiOperation(value = "An implicit params operation")
-    @ApiImplicitParams(
-        @ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body")
-    )
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body"),
+        @ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
+    })
     @RequestMapping(path = "/implicitparams", method = RequestMethod.POST)
     public String implicitParams(String requestModel) {
         return "";

--- a/src/test/kotlin/com/benjaminsproule/swagger/gradleplugin/test/kotlin/jaxrs/TestResourceWithClassAnnotation.kt
+++ b/src/test/kotlin/com/benjaminsproule/swagger/gradleplugin/test/kotlin/jaxrs/TestResourceWithClassAnnotation.kt
@@ -145,7 +145,8 @@ open class TestResourceWithClassAnnotation {
 
     @ApiOperation(value = "An implicit params operation")
     @ApiImplicitParams(
-        ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body")
+        ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body"),
+        ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
     )
     @Path("/implicitparams")
     @POST

--- a/src/test/kotlin/com/benjaminsproule/swagger/gradleplugin/test/kotlin/springmvc/TestResourceWithClassAnnotation.kt
+++ b/src/test/kotlin/com/benjaminsproule/swagger/gradleplugin/test/kotlin/springmvc/TestResourceWithClassAnnotation.kt
@@ -131,7 +131,8 @@ open class TestResourceWithClassAnnotation {
 
     @ApiOperation(value = "An implicit params operation")
     @ApiImplicitParams(
-        ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body")
+        ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body"),
+        ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
     )
     @RequestMapping(path = ["/implicitparams"], method = [RequestMethod.POST])
     fun implicitParams(requestModel: String): String {

--- a/src/test/scala/com/benjaminsproule/swagger/gradleplugin/test/scala/jaxrs/TestResourceWithClassAnnotation.scala
+++ b/src/test/scala/com/benjaminsproule/swagger/gradleplugin/test/scala/jaxrs/TestResourceWithClassAnnotation.scala
@@ -143,7 +143,8 @@ class TestResourceWithClassAnnotation {
 
     @ApiOperation(value = "An implicit params operation")
     @ApiImplicitParams(Array(
-        new ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body")
+        new ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body"),
+        new ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
     ))
     @Path("/implicitparams")
     @POST

--- a/src/test/scala/com/benjaminsproule/swagger/gradleplugin/test/scala/springmvc/TestResourceWithClassAnnotation.scala
+++ b/src/test/scala/com/benjaminsproule/swagger/gradleplugin/test/scala/springmvc/TestResourceWithClassAnnotation.scala
@@ -127,7 +127,8 @@ class TestResourceWithClassAnnotation {
 
     @ApiOperation(value = "An implicit params operation")
     @ApiImplicitParams(Array(
-        new ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body")
+        new ApiImplicitParam(name = "body", required = true, dataType = "com.benjaminsproule.swagger.gradleplugin.test.model.RequestModel", paramType = "body"),
+        new ApiImplicitParam(name = "id", value = "Implicit parameter of primitive type string", dataType = "string",  paramType = "header")
     ))
     @RequestMapping(path = Array("/implicitparams"), method = Array(RequestMethod.POST))
     def implicitParams(requestModel: String): String = {


### PR DESCRIPTION
dataType="string" implicit params are failing without the changes. I added the tests and the fix that resolves the class by using io.swagger.util.ReflectionUtils