### PR TITLE
Update ClassFinder.groovy

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
@@ -95,7 +95,7 @@ class ClassFinder {
             urls += it.toURI().toURL()
         }
 
-        if (project.sourceSets.main.output.getProperties()['classesDirs']) {
+        if (project.sourceSets.main.output.hasProperty('classesDirs')) {
             project.sourceSets.main.output.classesDirs.each {
                 if (it.exists()) {
                     urls += it.toURI().toURL()


### PR DESCRIPTION
Original 
project.sourceSets.main.output.getProperties()['classesDirs']
pulls ALL the properties leading to pull of deprecated properties which trigger deprecation warnings in build.