### PR TITLE
Fixed NPE when using a custom API Reader.

### DIFF
--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/ReaderFactory.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/ReaderFactory.groovy
@@ -76,7 +76,7 @@ class ReaderFactory {
             Class<?> clazz = customReaderClassFinder.loadClass(customReaderClassName)
             if (AbstractReader.isAssignableFrom(clazz)) {
                 Constructor<?> constructor = clazz.getConstructor(ApiSourceExtension, Set, List, ClassFinder)
-                return (ClassSwaggerReader) constructor.newInstance(apiSourceExtension, loadTypesToSkip(), resolveSwaggerExtensions(), ClassFinder)
+                return (ClassSwaggerReader) constructor.newInstance(apiSourceExtension, loadTypesToSkip(apiSourceExtension), resolveSwaggerExtensions(apiSourceExtension), classFinder)
             } else {
                 return (ClassSwaggerReader) clazz.getConstructor().newInstance()
             }


### PR DESCRIPTION
If we try to use a Custom Reader, the code will fail with a NPE in here:

https://github.com/gigaSproule/swagger-gradle-plugin/blob/master/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/ReaderFactory.groovy#L36

Since the method is being called with a null argument here:
https://github.com/gigaSproule/swagger-gradle-plugin/blob/master/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/reader/ReaderFactory.groovy#L79