### PR TITLE
more stable json sort order

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.7
+version=1.0.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.8
+version=1.0.7

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/Utils.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/Utils.groovy
@@ -2,6 +2,7 @@ package com.benjaminsproule.swagger.gradleplugin
 
 import com.benjaminsproule.swagger.gradleplugin.exceptions.GenerateException
 import io.swagger.models.*
+import io.swagger.models.parameters.Parameter
 import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.web.bind.annotation.RequestMapping
 
@@ -79,6 +80,12 @@ class Utils {
             Map<String, Response> responses = op.getResponses()
             TreeMap<String, Response> res = new TreeMap<String, Response>()
             res.putAll(responses)
+            op.getParameters().sort(new Comparator<Parameter>() {
+                @Override
+                int compare(Parameter o1, Parameter o2) {
+                    return o1.getName() <=> o2.getName()
+                }
+            })
             op.setResponses(res)
         } catch (NoSuchMethodException e) {
             throw new GenerateException(e)

--- a/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/generator/SwaggerSpecGenerator.groovy
+++ b/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/generator/SwaggerSpecGenerator.groovy
@@ -6,6 +6,7 @@ import com.benjaminsproule.swagger.gradleplugin.exceptions.GenerateException
 import com.benjaminsproule.swagger.gradleplugin.model.ApiSourceExtension
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -34,6 +35,8 @@ class SwaggerSpecGenerator implements Generator {
         //Not come across an appropriate solution that is not deprecated yet
         mapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false)
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 
         if (apiSource.jsonExampleValues) {
             mapper.addMixIn(Property, PropertyExampleMixIn)


### PR DESCRIPTION
We're finding that generated .json files have an unpredictable order (they're perfectly valid, but the json itself is shuffled up sometimes). This is causing gradle to treat most swagger defs as different files and thus things like up-to-date checks and remote build cache checks to fail. 

We're aware that this won't account for all scenarios, but its a helpful start.