### PR TITLE
Update gradle springboot swagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     maven {
         url 'https://dl.bintray.com/gigasproule/maven'

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,8 @@ dependencies {
     def kotlinVersion = '1.3.21'
 
     compile gradleApi()
-    compile localGroovy()
+    // compile localGroovy()
+    compile "org.codehaus.groovy:groovy-all:2.5.6"
 
     compile 'commons-io:commons-io:2.6'
     compile 'org.apache.commons:commons-lang3:3.8.1'

--- a/sample/groovy-spring-boot-jaxrs/build.gradle
+++ b/sample/groovy-spring-boot-jaxrs/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -19,7 +19,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/groovy-spring-boot-jaxrs/build.gradle
+++ b/sample/groovy-spring-boot-jaxrs/build.gradle
@@ -28,7 +28,8 @@ group = 'com.benjaminsproule'
 version = '0.0.1-SNAPSHOT'
 
 dependencies {
-    compile localGroovy()
+    // compile localGroovy()
+    compile "org.codehaus.groovy:groovy-all:2.5.6"
     compile 'org.springframework.boot:spring-boot-starter-jersey'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'io.swagger:swagger-annotations:1.5.15'

--- a/sample/groovy-spring-boot-jaxrs/build.gradle
+++ b/sample/groovy-spring-boot-jaxrs/build.gradle
@@ -30,10 +30,9 @@ version = '0.0.1-SNAPSHOT'
 dependencies {
     // compile localGroovy()
     compile "org.codehaus.groovy:groovy-all:2.5.6"
-    compile 'org.springframework.boot:spring-boot-starter-jersey'
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile 'org.springframework.boot:spring-boot-starter-jersey:2.1.3.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
 }
 
 swagger {

--- a/sample/groovy-spring-boot-mvc/build.gradle
+++ b/sample/groovy-spring-boot-mvc/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -19,7 +19,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/groovy-spring-boot-mvc/build.gradle
+++ b/sample/groovy-spring-boot-mvc/build.gradle
@@ -28,7 +28,8 @@ group = 'com.benjaminsproule'
 version = '0.0.1-SNAPSHOT'
 
 dependencies {
-    compile localGroovy()
+    // compile localGroovy()
+    compile "org.codehaus.groovy:groovy-all:2.5.6"
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'io.swagger:swagger-annotations:1.5.15'
 }

--- a/sample/groovy-spring-boot-mvc/build.gradle
+++ b/sample/groovy-spring-boot-mvc/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.5.4.RELEASE'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -30,8 +30,8 @@ version = '0.0.1-SNAPSHOT'
 dependencies {
     // compile localGroovy()
     compile "org.codehaus.groovy:groovy-all:2.5.6"
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
 }
 
 swagger {

--- a/sample/java-spring-boot-jaxrs/build.gradle
+++ b/sample/java-spring-boot-jaxrs/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -19,7 +19,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/java-spring-boot-jaxrs/build.gradle
+++ b/sample/java-spring-boot-jaxrs/build.gradle
@@ -13,10 +13,21 @@ buildscript {
     }
 }
 
+/*
 apply plugin: 'maven'
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
+ */
+
+plugins {
+    id 'java'
+    id 'maven'
+    id 'com.benjaminsproule.swagger' version '1.0.6'
+    // id 'org.springframework.boot'
+    id "org.springframework.boot" version "2.1.3.RELEASE"
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
+}
 
 repositories {
     // mavenLocal()

--- a/sample/java-spring-boot-jaxrs/build.gradle
+++ b/sample/java-spring-boot-jaxrs/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.5.4.RELEASE'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -28,14 +28,20 @@ group = 'com.benjaminsproule'
 version = '0.0.1-SNAPSHOT'
 
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-jersey'
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile 'org.springframework.boot:spring-boot-starter-jersey:2.1.3.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger:swagger-annotations:1.5.22'
+    // compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
+    compile 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 }
 
 swagger {
     apiSource {
+        attachSwaggerArtifact = true
+        locations = ['com.benjaminsproule.public']
+        swaggerDirectory = "${swaggerDirectory}"
+        swaggerFileName = 'publicSwagger'
+
         springmvc = false
         locations = ['com.benjaminsproule.sample']
         schemes = ['http', 'https']

--- a/sample/java-spring-boot-jaxrs/src/main/java/com/benjaminsproule/sample/springboot/jaxrs/SampleApplication.java
+++ b/sample/java-spring-boot-jaxrs/src/main/java/com/benjaminsproule/sample/springboot/jaxrs/SampleApplication.java
@@ -2,7 +2,7 @@ package com.benjaminsproule.sample.springboot.jaxrs;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
 public class SampleApplication extends SpringBootServletInitializer {

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -19,7 +19,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -50,6 +50,22 @@ dependencies {
     
     // additional openapi stuff
     compile "org.openapitools:openapi-generator-cli:4.0.0-beta2"
+    
+    // needed as dep for openapi generation for 'java'
+    compile 'com.google.code.gson:gson:2.8.5'
+    compile 'io.gsonfire:gson-fire:1.8.3'
+    compile 'com.squareup.okio:okio:2.2.2'
+    compile 'com.squareup.okhttp3:okhttp:3.14.0'
+    compile 'org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+            srcDir 'build/openapi/src/main/java'
+        }
+    }
 }
 
 def generateSwagger = swagger {
@@ -86,6 +102,8 @@ def generateSwagger = swagger {
     }
 }
 
+// https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-gradle-plugin/README.adoc
+// https://github.com/OpenAPITools/openapi-generator
 def generateApi = openApiGenerate {
     generatorName = "java" // kotlin
     // inputSpec = "$rootDir/specs/petstore-v3.0.yaml".toString()

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -45,6 +45,11 @@ dependencies {
 
 def generateSwagger = swagger {
     apiSource {
+        attachSwaggerArtifact = true
+        locations = ['com.benjaminsproule.public']
+        swaggerDirectory = "${swaggerDirectory}"
+        swaggerFileName = 'publicSwagger'
+        
         springmvc = true
         locations = ['com.benjaminsproule.sample']
         schemes = ['http', 'https']
@@ -78,4 +83,4 @@ springBoot {
 }
  */
 
-build.dependsOn generateSwagger
+// build.dependsOn generateSwagger

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile 'io.swagger:swagger-annotations:1.5.15'
 }
 
-swagger {
+def generateSwagger = swagger {
     apiSource {
         springmvc = true
         locations = ['com.benjaminsproule.sample']
@@ -78,4 +78,4 @@ springBoot {
 }
  */
 
-// build.dependsOn swagger
+build.dependsOn generateSwagger

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -10,6 +10,9 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath 'com.benjaminsproule:swagger-gradle-plugin:+'
+
+        // additional openapi stuff
+        classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.0-beta2"
     }
 }
 
@@ -29,6 +32,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.7.RELEASE'
 }
 
+apply plugin: 'org.openapi.generator'
+
 repositories {
     // mavenLocal()
     mavenCentral()
@@ -42,6 +47,9 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
     compile 'io.swagger:swagger-annotations:1.5.22'
     // compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
+    
+    // additional openapi stuff
+    compile "org.openapitools:openapi-generator-cli:4.0.0-beta2"
 }
 
 def generateSwagger = swagger {
@@ -78,10 +86,39 @@ def generateSwagger = swagger {
     }
 }
 
+def generateApi = openApiGenerate {
+    generatorName = "java" // kotlin
+    // inputSpec = "$rootDir/specs/petstore-v3.0.yaml".toString()
+    inputSpec = "$buildDir/swagger-ui/publicSwagger.json".toString()
+    outputDir = "$buildDir/openapi".toString()
+    apiPackage = "org.openapi.example.api"
+    invokerPackage = "org.openapi.example.invoker"
+    modelPackage = "org.openapi.example.model"
+    skipValidateSpec = false
+    /*
+    modelFilesConstrainedTo = [
+        "Error"
+    ]
+     */
+    configOptions = [
+        dateLibrary: "java8"
+    ]
+}
+
+task initOpenApi() {
+    doFirst {
+        mkdir "build/openapi"
+    }
+}
+
 /*
 springBoot {
     // mainClass = "com.benjaminsproule.sample.springboot.mvc.SampleApplication"
 }
  */
 
+// generateApi.dependsOn initOpenApi
+// build.dependsOn generateApi
 // build.dependsOn generateSwagger
+
+build.dependsOn initOpenApi

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     
     // additional openapi stuff
     compile "org.openapitools:openapi-generator-cli:4.0.0-beta2"
+    compile "org.openapitools:jackson-databind-nullable:0.1.0"
     
     // needed as dep for openapi generation for 'java'
     compile 'com.google.code.gson:gson:2.8.5'
@@ -57,6 +58,19 @@ dependencies {
     compile 'com.squareup.okio:okio:2.2.2'
     compile 'com.squareup.okhttp3:okhttp:3.14.0'
     compile 'org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2'
+
+    // needed as dep for openapi generation for 'spring'
+    compile 'io.springfox:springfox-spi:2.9.2'
+    compile 'io.springfox:springfox-schema:2.9.2'
+    compile 'io.springfox:springfox-spring-web:2.9.2'
+    // compile 'io.springfox:springfox-spring-webmvc:2.9.2'
+    // compile 'io.springfox:springfox-spring-integration:2.9.2'
+    // https://springfox.github.io/springfox/docs/current/
+    compile "io.springfox:springfox-swagger2:2.9.2"
+    compile "io.springfox:springfox-data-rest:2.9.2"
+    compile "io.springfox:springfox-bean-validators:2.9.2"
+    compile 'io.springfox:springfox-swagger-ui:2.9.2'
+    compile 'io.springfox.ui:springfox-swagger-ui-rfc6570:1.0.0'
 }
 
 sourceSets {
@@ -105,7 +119,7 @@ def generateSwagger = swagger {
 // https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-gradle-plugin/README.adoc
 // https://github.com/OpenAPITools/openapi-generator
 def generateApi = openApiGenerate {
-    generatorName = "java" // kotlin
+    generatorName = "spring" // kotlin, java
     // inputSpec = "$rootDir/specs/petstore-v3.0.yaml".toString()
     inputSpec = "$buildDir/swagger-ui/publicSwagger.json".toString()
     outputDir = "$buildDir/openapi".toString()

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.5.4.RELEASE'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -40,7 +40,8 @@ version = '0.0.1-SNAPSHOT'
 
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
-    compile 'io.swagger:swagger-annotations:1.5.15'
+    compile 'io.swagger:swagger-annotations:1.5.22'
+    // compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
 }
 
 def generateSwagger = swagger {

--- a/sample/java-spring-boot-mvc/build.gradle
+++ b/sample/java-spring-boot-mvc/build.gradle
@@ -13,10 +13,21 @@ buildscript {
     }
 }
 
+/*
 apply plugin: 'maven'
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
+*/
+
+plugins {
+    id 'java'
+    id 'maven'
+    id 'com.benjaminsproule.swagger' version '1.0.6'
+    // id 'org.springframework.boot'
+    id "org.springframework.boot" version "2.1.3.RELEASE"
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
+}
 
 repositories {
     // mavenLocal()
@@ -28,7 +39,7 @@ group = 'com.benjaminsproule'
 version = '0.0.1-SNAPSHOT'
 
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-web'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
     compile 'io.swagger:swagger-annotations:1.5.15'
 }
 
@@ -60,3 +71,11 @@ swagger {
         }
     }
 }
+
+/*
+springBoot {
+    // mainClass = "com.benjaminsproule.sample.springboot.mvc.SampleApplication"
+}
+ */
+
+// build.dependsOn swagger

--- a/sample/kotlin-spring-boot-jaxrs/build.gradle
+++ b/sample/kotlin-spring-boot-jaxrs/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        kotlinVersion = '1.3.10'
-        springBootVersion = '1.5.4.RELEASE'
+        kotlinVersion = '1.3.21'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -32,14 +32,20 @@ version = '0.0.1-SNAPSHOT'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
-    compile 'org.springframework.boot:spring-boot-starter-jersey'
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile 'org.springframework.boot:spring-boot-starter-jersey:2.1.3.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger:swagger-annotations:1.5.22'
+    // compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
+    compile 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 }
 
 swagger {
     apiSource {
+        attachSwaggerArtifact = true
+        locations = ['com.benjaminsproule.public']
+        swaggerDirectory = "${swaggerDirectory}"
+        swaggerFileName = 'publicSwagger'
+
         springmvc = false
         locations = ['com.benjaminsproule.sample']
         schemes = ['http', 'https']

--- a/sample/kotlin-spring-boot-jaxrs/build.gradle
+++ b/sample/kotlin-spring-boot-jaxrs/build.gradle
@@ -16,10 +16,20 @@ buildscript {
     }
 }
 
+plugins {
+    id 'java'
+    id 'org.jetbrains.kotlin.plugin.spring' version "1.3.21"
+    id 'com.benjaminsproule.swagger' version '1.0.6'
+    id "org.springframework.boot" version "2.1.3.RELEASE"
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
+}
+
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-spring'
+/*
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
+ */
 
 repositories {
     // mavenLocal()
@@ -71,4 +81,19 @@ swagger {
             json = 'securityDefinition.json'
         }
     }
+}
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+        freeCompilerArgs = ["-Xjsr305=strict"]
+    }
+}
+
+jar {
+    enabled = true
+}
+
+springBoot {
+    mainClassName = "com.benjaminsproule.sample.kotlin.SampleApplication.kt"
 }

--- a/sample/kotlin-spring-boot-jaxrs/build.gradle
+++ b/sample/kotlin-spring-boot-jaxrs/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -22,7 +22,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/kotlin-spring-boot-mvc/build.gradle
+++ b/sample/kotlin-spring-boot-mvc/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }

--- a/sample/kotlin-spring-boot-mvc/build.gradle
+++ b/sample/kotlin-spring-boot-mvc/build.gradle
@@ -16,10 +16,20 @@ buildscript {
     }
 }
 
+plugins {
+    id 'java'
+    id 'org.jetbrains.kotlin.plugin.spring' version "1.3.21"
+    id 'com.benjaminsproule.swagger' version '1.0.6'
+    id "org.springframework.boot" version "2.1.3.RELEASE"
+    id 'io.spring.dependency-management' version '1.0.7.RELEASE'
+}
+
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-spring'
+/*
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
+ */
 
 repositories {
     mavenLocal()
@@ -69,4 +79,19 @@ swagger {
             json = 'securityDefinition.json'
         }
     }
+}
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+        freeCompilerArgs = ["-Xjsr305=strict"]
+    }
+}
+
+jar {
+    enabled = true
+}
+
+springBoot {
+    mainClassName = "com.benjaminsproule.sample.kotlin.SampleApplication.kt"
 }

--- a/sample/kotlin-spring-boot-mvc/build.gradle
+++ b/sample/kotlin-spring-boot-mvc/build.gradle
@@ -32,7 +32,7 @@ apply plugin: 'com.benjaminsproule.swagger'
  */
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/kotlin-spring-boot-mvc/build.gradle
+++ b/sample/kotlin-spring-boot-mvc/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        kotlinVersion = '1.3.10'
-        springBootVersion = '1.5.4.RELEASE'
+        kotlinVersion = '1.3.21'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -32,12 +32,18 @@ version = '0.0.1-SNAPSHOT'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger:swagger-annotations:1.5.22'
+    // compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
 }
 
 swagger {
     apiSource {
+        attachSwaggerArtifact = true
+        locations = ['com.benjaminsproule.public']
+        swaggerDirectory = "${swaggerDirectory}"
+        swaggerFileName = 'publicSwagger'
+
         springmvc = true
         locations = ['com.benjaminsproule.sample']
         schemes = ['http', 'https']

--- a/sample/scala-spring-boot-jaxrs/build.gradle
+++ b/sample/scala-spring-boot-jaxrs/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -18,7 +18,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/scala-spring-boot-jaxrs/build.gradle
+++ b/sample/scala-spring-boot-jaxrs/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.5.4.RELEASE'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -28,10 +28,10 @@ version = '0.0.1-SNAPSHOT'
 
 dependencies {
     compile 'org.scala-lang:scala-library:2.12.7'
-    compile 'org.springframework.boot:spring-boot-starter-jersey'
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
-    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile 'org.springframework.boot:spring-boot-starter-jersey:2.1.3.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
+    compile 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 }
 
 swagger {

--- a/sample/scala-spring-boot-mvc/build.gradle
+++ b/sample/scala-spring-boot-mvc/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         springBootVersion = '1.5.4.RELEASE'
     }
     repositories {
-        mavenLocal()
+        // mavenLocal()
         mavenCentral()
         jcenter()
     }
@@ -18,7 +18,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'com.benjaminsproule.swagger'
 
 repositories {
-    mavenLocal()
+    // mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/sample/scala-spring-boot-mvc/build.gradle
+++ b/sample/scala-spring-boot-mvc/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.5.4.RELEASE'
+        springBootVersion = '2.1.3.RELEASE'
     }
     repositories {
         // mavenLocal()
@@ -28,8 +28,9 @@ version = '0.0.1-SNAPSHOT'
 
 dependencies {
     compile 'org.scala-lang:scala-library:2.12.7'
-    compile 'org.springframework.boot:spring-boot-starter-web'
-    compile 'io.swagger:swagger-annotations:1.5.15'
+    compile 'org.springframework.boot:spring-boot-starter-web:2.1.3.RELEASE'
+    compile 'io.swagger:swagger-annotations:1.5.22'
+    // compile 'io.swagger.core.v3:swagger-annotations:2.0.7'
 }
 
 swagger {

--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPluginITest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPluginITest.groovy
@@ -493,7 +493,7 @@ class GradleSwaggerPluginITest extends AbstractPluginITest {
             }
 
             repositories {
-                mavenLocal()
+                // mavenLocal()
                 mavenCentral()
             }
 


### PR DESCRIPTION
The following is a (perhaps incomplete) update of the following:

* working with gradle 5.1.1
* spring boot to 2.1.3.RELEASE
* kotlin to 1.3.21
* rs-api to 2.1.1

In addition it removes the `mavenLocal()` and `groovyLocal()` from the gradle builds.

Perhaps this is useful as reference.