### PR TITLE
Remove originalRef and responseSchema entities from generated swaggers

### DIFF
--- a/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/JsonViewSupportTest.groovy
+++ b/src/test/groovy/com/benjaminsproule/swagger/gradleplugin/JsonViewSupportTest.groovy
@@ -55,17 +55,20 @@ class JsonViewSupportTest extends AbstractPluginITest {
         def withViewOne = paths."/api/jsonview/with/1".get
         assert withViewOne
         assert withViewOne.operationId == "withJsonViewOne"
-        assert withViewOne.responses."200".responseSchema.originalRef == "#/definitions/TestJsonViewEntity_TestJsonViewOne"
+        assert withViewOne.responses."200".schema.$ref == "#/definitions/TestJsonViewEntity_TestJsonViewOne"
+        assert withViewOne.responses."200".responseSchema == null
 
         def withViewTwo = paths."/api/jsonview/with/2".get
         assert withViewTwo
         assert withViewTwo.operationId == "withJsonViewTwo"
-        assert withViewTwo.responses."200".responseSchema.originalRef == "#/definitions/TestJsonViewEntity_TestJsonViewTwo"
+        assert withViewTwo.responses."200".schema.$ref == "#/definitions/TestJsonViewEntity_TestJsonViewTwo"
+        assert withViewTwo.responses."200".responseSchema == null
 
         def withoutAny = paths."/api/jsonview/without".post
         assert withoutAny
         assert withoutAny.operationId == "withoutJsonView"
-        assert withoutAny.responses."200".responseSchema.originalRef == "#/definitions/TestJsonViewEntity"
+        assert withoutAny.responses."200".schema.$ref == "#/definitions/TestJsonViewEntity"
+        assert withoutAny.responses."200".responseSchema == null
 
         // assert definitions
         def definitions = producedSwaggerDocument.definitions
@@ -130,17 +133,20 @@ class JsonViewSupportTest extends AbstractPluginITest {
         def withViewOne = paths."/api/jsonview/with/1".get
         assert withViewOne
         assert withViewOne.operationId == "withJsonViewOne"
-        assert withViewOne.responses."200".responseSchema.originalRef == "#/definitions/TestJsonViewEntity_TestJsonViewOne"
+        assert withViewOne.responses."200".schema.$ref == "#/definitions/TestJsonViewEntity_TestJsonViewOne"
+        assert withViewOne.responses."200".responseSchema == null
 
         def withViewTwo = paths."/api/jsonview/with/2".get
         assert withViewTwo
         assert withViewTwo.operationId == "withJsonViewTwo"
-        assert withViewTwo.responses."200".responseSchema.originalRef == "#/definitions/TestJsonViewEntity_TestJsonViewTwo"
+        assert withViewTwo.responses."200".schema.$ref == "#/definitions/TestJsonViewEntity_TestJsonViewTwo"
+        assert withViewTwo.responses."200".responseSchema == null
 
         def withoutAny = paths."/api/jsonview/without".post
         assert withoutAny
         assert withoutAny.operationId == "withoutJsonView"
-        assert withoutAny.responses."200".responseSchema.originalRef == "#/definitions/TestJsonViewEntity"
+        assert withoutAny.responses."200".schema.$ref == "#/definitions/TestJsonViewEntity"
+        assert withoutAny.responses."200".responseSchema == null
 
         // assert definitions
         def definitions = producedSwaggerDocument.definitions


### PR DESCRIPTION
Since swagger-core version 1.5.21, these elements are being generated by the ObjectMapper if it is not configured properly.
These don't conform to the swagger standard and the plugin in its turn generates swagger files that contain errors. These can be seen both in the official swagger parser and the online swagger editor.

To avoid their generation, I used the standard factory method to generate the mappers (which down the line prevent the generation of those elements).
In addition, since the Yaml mapper and the Json mapper were initialized differently in the code (making the Yaml version, not to present the above issue, by the way), made sure they are both initialized by the standard factory, and the custom configurations being applied to both.

Also streamlined the output code to reuse the same method, for clarity.
Updated the tests not to look for the incorrect elements and made sure they don't show up again.

This should resolve issue 157.