### PR TITLE
delay runtime deps resolution to execution time

### DIFF
--- a/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPlugin.groovy
+++ b/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPlugin.groovy
@@ -62,7 +62,10 @@ class GradleSwaggerPlugin implements Plugin<Project> {
             }.findAll {
                 it != null
             }
-            generateSwaggerDocsTask.inputFiles = project.configurations.findByName("runtime")?.fileCollection() ?: []
+            generateSwaggerDocsTask.inputFiles = (
+                project.configurations.findByName("runtime") ?:
+                project.configurations.findByName("runtimeClasspath")
+            ).fileCollection()
         }
     }
 }

--- a/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPlugin.groovy
+++ b/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPlugin.groovy
@@ -62,7 +62,7 @@ class GradleSwaggerPlugin implements Plugin<Project> {
             }.findAll {
                 it != null
             }
-            generateSwaggerDocsTask.inputFiles = project.configurations.getByName("runtime").files()
+            generateSwaggerDocsTask.inputFiles = project.configurations.getByName("runtime").fileCollection()
         }
     }
 }

--- a/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPlugin.groovy
+++ b/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/GradleSwaggerPlugin.groovy
@@ -62,7 +62,7 @@ class GradleSwaggerPlugin implements Plugin<Project> {
             }.findAll {
                 it != null
             }
-            generateSwaggerDocsTask.inputFiles = project.configurations.getByName("runtime").fileCollection()
+            generateSwaggerDocsTask.inputFiles = project.configurations.findByName("runtime")?.fileCollection() ?: []
         }
     }
 }


### PR DESCRIPTION
This PR applies the change proposed on issue #246.

I've tested it on one of my projects and it worked correctly with **gradle 7.1.1**.
The dependency resolution was postponed to execution time.
