### PR TITLE
Fixing method name typo in ClassFinder.groovy.

### DIFF
--- a/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
+++ b/plugin/src/main/groovy/com/benjaminsproule/swagger/gradleplugin/classpath/ClassFinder.groovy
@@ -76,7 +76,7 @@ class ClassFinder {
 
         } else {
             LOG.warn("Scanning the the entire classpath (${clazz}), you should avoid this by specifying package locations")
-            Set<Class<?>> c = new Reflections(getClassLoader(), '').getTygetValidClassespesAnnotatedWith(clazz)
+            Set<Class<?>> c = new Reflections(getClassLoader(), '').getTypesAnnotatedWith(clazz)
             classes.addAll(c)
         }
 


### PR DESCRIPTION
Fixing method name typo